### PR TITLE
last_try 필드에 default 추가

### DIFF
--- a/check/models.py
+++ b/check/models.py
@@ -11,7 +11,7 @@ class Solver(models.Model):
     prob_num = models.IntegerField()
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     solved_at = models.DateTimeField(auto_now_add=True)
-    last_try = models.IntegerField()
+    last_try = models.IntegerField(default=0)
     
     def __str__(self):
         return str(self.user.username)


### PR DESCRIPTION
default가 없어서 migration 시에 default를 직접 지정해주어야 하는데, 그것보단 default 값이 명시되어있는 편이 좋겠습니다.